### PR TITLE
Mask Authorization Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ hs_err_pid*
 # Icon must end with two \r
 Icon
 
+# Eclipse
+
+.classpath
+.project
+.settings/
+
 
 # Thumbnails
 ._*

--- a/src/main/java/devcsrj/okhttp3/logging/HttpLoggingInterceptor.java
+++ b/src/main/java/devcsrj/okhttp3/logging/HttpLoggingInterceptor.java
@@ -22,6 +22,7 @@ import static okhttp3.internal.http.StatusLine.HTTP_CONTINUE;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import okhttp3.Connection;
 import okhttp3.Headers;
@@ -128,10 +129,12 @@ public final class HttpLoggingInterceptor implements Interceptor {
             Headers headers = request.headers();
             for (int i = 0; i < headers.size(); i++) {
                 String name = headers.name( i );
+                String value = Objects.equals((name + "").trim(), "Authorization") ? "******" : headers.value(i);
 
-                // Skip headers from the request body as they are explicitly logged above.
-                if (!"Content-Type".equalsIgnoreCase( name ) && !"Content-Length".equalsIgnoreCase( name ))
-                    logger.info( "{}: {}", name, headers.value( i ) );
+				// Skip headers from the request body as they are explicitly
+				// logged above.
+				if (!"Content-Type".equalsIgnoreCase(name) && !"Content-Length".equalsIgnoreCase(name))
+					logger.info("{}: {}", name, value);
             }
 
             if (!logBody || !hasRequestBody)


### PR DESCRIPTION
if you aggregate your logs and use for example OAuth2 authentification no token should be in the logs